### PR TITLE
Adding velocity costmaps to DWA planner

### DIFF
--- a/base_local_planner/CMakeLists.txt
+++ b/base_local_planner/CMakeLists.txt
@@ -83,6 +83,7 @@ add_library(base_local_planner
 	src/local_planner_util.cpp
 	src/odometry_helper_ros.cpp
 	src/obstacle_cost_function.cpp
+        src/velocity_costmaps_cost_function.cpp
 	src/oscillation_cost_function.cpp
 	src/prefer_forward_cost_function.cpp
 	src/point_grid.cpp

--- a/base_local_planner/cfg/BaseLocalPlanner.cfg
+++ b/base_local_planner/cfg/BaseLocalPlanner.cfg
@@ -29,6 +29,7 @@ gen.add("angular_sim_granularity", double_t, 0, "The distance between simulation
 gen.add("pdist_scale", double_t, 0, "The weight for the path distance part of the cost function", 0.6, 0, 5)
 gen.add("gdist_scale", double_t, 0, "The weight for the goal distance part of the cost function", 0.8, 0, 5)
 gen.add("occdist_scale", double_t, 0, "The weight for the obstacle distance part of the cost function", 0.01, 0, 5)
+gen.add("velmaps_scale", double_t, 0, "The weight for the velocity costmaps part of the cost function", 1.0, 0, 5)
 
 gen.add("oscillation_reset_dist", double_t, 0, "The distance the robot must travel before oscillation flags are reset, in meters", 0.05, 0, 5)
 gen.add("escape_reset_dist", double_t, 0, "The distance the robot must travel before oscillation flags are reset, in meters", 0.10, 0, 5)

--- a/base_local_planner/include/base_local_planner/velocity_costmaps_cost_function.h
+++ b/base_local_planner/include/base_local_planner/velocity_costmaps_cost_function.h
@@ -1,0 +1,56 @@
+#ifndef VELOCITY_COSTMAPS_COST_FUNCTION_H_
+#define VELOCITY_COSTMAPS_COST_FUNCTION_H_
+
+#include <base_local_planner/trajectory_cost_function.h>
+
+#include <base_local_planner/costmap_model.h>
+#include <costmap_2d/costmap_2d.h>
+#include <ros/ros.h>
+#include <std_msgs/String.h>
+#include <nav_msgs/OccupancyGrid.h>
+#include <boost/thread/mutex.hpp>
+
+namespace base_local_planner {
+
+/**
+ * class ObstacleCostFunction
+ * @brief Uses costmap 2d to assign negative costs if robot footprint
+ * is in obstacle on any point of the trajectory.
+ */
+class VelocityCostmapsCostFunction : public TrajectoryCostFunction {
+
+public:
+  VelocityCostmapsCostFunction();
+  ~VelocityCostmapsCostFunction();
+
+  bool prepare();
+  double scoreTrajectory(Trajectory &traj);
+
+  void setParams(double max_vel_x) {
+      max_vel_x_ = max_vel_x;
+  }
+
+  virtual float getCost(unsigned int cx, unsigned int cy){ return 0; }
+
+  void callback(const nav_msgs::OccupancyGrid::ConstPtr &msg);
+
+private:
+  inline unsigned int getIndex(unsigned int mx, unsigned int my, unsigned int size_x) const
+  {
+    return my * size_x + mx;
+  }
+
+  inline void check_map() {
+      if(ros::Time::now() > map_.header.stamp + ros::Duration(2))
+          map_.info.width = 0;
+  }
+
+  double max_vel_x_, costs_xv_, costs_tv_;
+  ros::Subscriber sub;
+  ros::Publisher pub;
+  nav_msgs::OccupancyGrid map_, pub_map_;
+  boost::mutex mutex;
+};
+
+} /* namespace base_local_planner */
+#endif /* VELOCITY_COSTMAPS_COST_FUNCTION_H_ */

--- a/base_local_planner/src/velocity_costmaps_cost_function.cpp
+++ b/base_local_planner/src/velocity_costmaps_cost_function.cpp
@@ -47,7 +47,7 @@ double VelocityCostmapsCostFunction::scoreTrajectory(Trajectory &traj) {
 //        cost = fmax(traj.xv_ * costs_xv_,fabs(traj.thetav_ * costs_tv_));
         cost = traj.xv_ * costs_xv_ + fabs(traj.thetav_ * costs_tv_);
 
-        ROS_INFO("Speed: x: %f, theta: %f, index: (%d, %d) = %d, %d -> costs: %.2f, x: %.2f, t: %.2f", traj.xv_, traj.thetav_, x, y, index_x, index_t, cost, traj.xv_ * costs_xv_, fabs(traj.thetav_ * costs_tv_));
+//        ROS_INFO("Speed: x: %f, theta: %f, index: (%d, %d) = %d, %d -> costs: %.2f, x: %.2f, t: %.2f", traj.xv_, traj.thetav_, x, y, index_x, index_t, cost, traj.xv_ * costs_xv_, fabs(traj.thetav_ * costs_tv_));
         if(pub.getNumSubscribers()){
             pub_map_.data[index_x] = 98; // Just for visualisation, these costs have no effect on the planning
             pub_map_.data[index_t] = 50;

--- a/base_local_planner/src/velocity_costmaps_cost_function.cpp
+++ b/base_local_planner/src/velocity_costmaps_cost_function.cpp
@@ -1,0 +1,65 @@
+#include <base_local_planner/velocity_costmaps_cost_function.h>
+#include <cmath>
+#include <Eigen/Core>
+#include <ros/console.h>
+
+using base_local_planner::Trajectory;
+
+namespace base_local_planner {
+
+VelocityCostmapsCostFunction::VelocityCostmapsCostFunction() {
+    costs_xv_ = 0.0;
+    costs_tv_ = 0.0;
+
+    ros::NodeHandle nh("~");
+    sub = nh.subscribe("/velocity_costmap_server/map", 10, &VelocityCostmapsCostFunction::callback, this);
+    pub = nh.advertise<nav_msgs::OccupancyGrid>("velocity_costmap", 10);
+}
+
+VelocityCostmapsCostFunction::~VelocityCostmapsCostFunction() {}
+
+
+bool VelocityCostmapsCostFunction::prepare() {
+    if(pub.getNumSubscribers() && map_.info.width != 0){
+        pub.publish(pub_map_);
+    }
+    return true;
+}
+
+double VelocityCostmapsCostFunction::scoreTrajectory(Trajectory &traj) {
+//    ROS_INFO("VELMAPS");
+    boost::mutex::scoped_lock lock(mutex);
+    double cost = 0;
+    if (sub.getNumPublishers() && map_.info.width != 0 && map_.info.height != 0) {
+        double xv = traj.xv_ * 100;
+        double tv = traj.thetav_ * M_PI;
+        int x = xv * cos(tv);
+        int y = xv * sin(tv);
+
+        double xvt = max_vel_x_ * 100; // Projecting the angluar velocity outwards to prevent spinning on the spot when the velmap allows no movement.
+        int xt = xvt * cos(tv);        // Might not be necessary, needs testing on robot.
+        int yt = xvt * sin(tv);
+
+        unsigned int index_x = VelocityCostmapsCostFunction::getIndex((x+(map_.info.width/2))-1, (y+(map_.info.height/2))-1, map_.info.width);
+        unsigned int index_t = VelocityCostmapsCostFunction::getIndex((xt+(map_.info.width/2))-1, (yt+(map_.info.height/2))-1, map_.info.width);
+        costs_xv_ = double(map_.data[index_x]);
+        costs_tv_ = double(map_.data[index_t]);
+//        cost = fmax(traj.xv_ * costs_xv_,fabs(traj.thetav_ * costs_tv_));
+        cost = traj.xv_ * costs_xv_ + fabs(traj.thetav_ * costs_tv_);
+
+        ROS_INFO("Speed: x: %f, theta: %f, index: (%d, %d) = %d, %d -> costs: %.2f, x: %.2f, t: %.2f", traj.xv_, traj.thetav_, x, y, index_x, index_t, cost, traj.xv_ * costs_xv_, fabs(traj.thetav_ * costs_tv_));
+        if(pub.getNumSubscribers()){
+            pub_map_.data[index_x] = 98; // Just for visualisation, these costs have no effect on the planning
+            pub_map_.data[index_t] = 50;
+        }
+        VelocityCostmapsCostFunction::check_map();
+    }
+    return cost;
+}
+
+void VelocityCostmapsCostFunction::callback(const nav_msgs::OccupancyGrid::ConstPtr &msg){
+    boost::mutex::scoped_lock lock(mutex);
+    map_ = *msg;
+    pub_map_ = map_;
+}
+} /* namespace base_local_planner */

--- a/base_local_planner/src/velocity_costmaps_cost_function.cpp
+++ b/base_local_planner/src/velocity_costmaps_cost_function.cpp
@@ -12,7 +12,9 @@ VelocityCostmapsCostFunction::VelocityCostmapsCostFunction() {
     costs_tv_ = 0.0;
 
     ros::NodeHandle nh("~");
-    sub = nh.subscribe("/velocity_costmap_server/map", 10, &VelocityCostmapsCostFunction::callback, this);
+    std::string topic = "/velocity_costmap";
+    nh.param("velocity_costmap_topic", topic, topic);
+    sub = nh.subscribe(topic, 10, &VelocityCostmapsCostFunction::callback, this);
     pub = nh.advertise<nav_msgs::OccupancyGrid>("velocity_costmap", 10);
 }
 

--- a/dwa_local_planner/cfg/DWAPlanner.cfg
+++ b/dwa_local_planner/cfg/DWAPlanner.cfg
@@ -19,6 +19,7 @@ gen.add("angular_sim_granularity", double_t, 0, "The granularity with which to c
 gen.add("path_distance_bias", double_t, 0, "The weight for the path distance part of the cost function", 32.0, 0.0)
 gen.add("goal_distance_bias", double_t, 0, "The weight for the goal distance part of the cost function", 24.0, 0.0)
 gen.add("occdist_scale", double_t, 0, "The weight for the obstacle distance part of the cost function", 0.01, 0.0)
+gen.add("velmaps_scale", double_t, 0, "The weight for the velocity costmaps part of the cost function", 42.0, 0.0)
 
 gen.add("stop_time_buffer", double_t, 0, "The amount of time that the robot must stop before a collision in order for a trajectory to be considered valid in seconds", 0.2, 0)
 gen.add("oscillation_reset_dist", double_t, 0, "The distance the robot must travel before oscillation flags are reset, in meters", 0.05, 0)

--- a/dwa_local_planner/include/dwa_local_planner/dwa_planner.h
+++ b/dwa_local_planner/include/dwa_local_planner/dwa_planner.h
@@ -58,6 +58,7 @@
 #include <base_local_planner/oscillation_cost_function.h>
 #include <base_local_planner/map_grid_cost_function.h>
 #include <base_local_planner/obstacle_cost_function.h>
+#include <base_local_planner/velocity_costmaps_cost_function.h>
 #include <base_local_planner/simple_scored_sampling_planner.h>
 
 #include <nav_msgs/Path.h>
@@ -147,7 +148,7 @@ namespace dwa_local_planner {
       base_local_planner::LocalPlannerUtil *planner_util_;
 
       double stop_time_buffer_; ///< @brief How long before hitting something we're going to enforce that the robot stop
-      double pdist_scale_, gdist_scale_, occdist_scale_;
+      double pdist_scale_, gdist_scale_, occdist_scale_, velmaps_scale_;
       Eigen::Vector3f vsamples_;
 
       double sim_period_;///< @brief The number of seconds to use to compute max/min vels for dwa
@@ -175,6 +176,7 @@ namespace dwa_local_planner {
       base_local_planner::MapGridCostFunction goal_costs_;
       base_local_planner::MapGridCostFunction goal_front_costs_;
       base_local_planner::MapGridCostFunction alignment_costs_;
+      base_local_planner::VelocityCostmapsCostFunction velo_maps_costs_;
 
       base_local_planner::SimpleScoredSamplingPlanner scored_sampling_planner_;
   };


### PR DESCRIPTION
Velocity costmaps are standard `nav_msgs/OccupancyGrid` messages which are usually used for metric maps and costmaps. In this case, velocity costmaps work in polar space and assign costs to linear/angular velocity combinations based on the value of the corresponding pixel of that map. See https://www.youtube.com/watch?v=evWTA8FcYJo for explanation.

This listens to `/velocity_costmap_server/map` for the costmap. This is currently hard-coded but will be made a parameter. If no map is published, 0 costs are assigned; Does therefore not change the defualt behaviour. The weight of the velocity costmaps costs can be adjusted dynamically with `velmaps_scale`.

This also publishes a new occupancy map on `/move_base/velocity_costmap` visualising the velocity costmap including the sampled trajectories as coloured points.

Tested in simulation. Will test on Linda and might include minor improvements. No merge yet please.
